### PR TITLE
KafkaTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.jsoup:jsoup:1.14.3'
+    implementation 'org.jsoup:jsoup:1.14.3' // 크롤링
+    implementation 'org.springframework.kafka:spring-kafka' // 카프카
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/example/crawling/CrawlingApplication.java
+++ b/src/main/java/com/example/crawling/CrawlingApplication.java
@@ -24,7 +24,7 @@ public class CrawlingApplication {
     public static void main(String[] args) throws IOException {
 
         SpringApplication.run(CrawlingApplication.class, args);
-        try {
+       /* try {
             //개발 강의 전부 순회.
             for (int i = First; i <= Last; i++) {
                 final String infUrl = "http://www.inflearn.com/courses/it-programming?order=seq&page=" + i;
@@ -137,6 +137,7 @@ public class CrawlingApplication {
     }
     private static String getSessionCount(final String course) {
         return removeNum(course.substring(0,course.indexOf("개")));
+    }*/
     }
 }
 

--- a/src/main/java/com/example/crawling/KafkaConsumer.java
+++ b/src/main/java/com/example/crawling/KafkaConsumer.java
@@ -1,0 +1,57 @@
+package com.example.crawling;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+
+public class KafkaConsumer {
+    private static final String TOPIC_NAME = "kafkaTest1";
+    private static final String FIN_MESSAGE = "exit";
+
+
+    public static void main(String[] args) {
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", "localhost:9092"); // 카프카 서버의 위치를 지정.
+        properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer"); // 메시지의 키를 역직렬화하는데 사용한 deserializer(byte -> String)클래스 지정.
+        properties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer"); // 메시지의 값을 역직렬화하는데 사용한 deserializer(byte -> String)클래스 지정.
+        properties.put("group.id", "NotificationGroup");
+
+        Consumer<String,String> consumer = new org.apache.kafka.clients.consumer.KafkaConsumer<>(properties);
+        consumer.subscribe(Collections.singletonList(TOPIC_NAME));
+
+
+        String message = null;
+
+        try {
+            do{
+                ConsumerRecords<String,String> records = consumer.poll(Duration.ofMillis(10000));
+                for(ConsumerRecord<String,String> record : records) {
+                    message = record.value();
+                    System.out.println(message);
+                }
+            }while (!StringUtils.pathEquals(message,FIN_MESSAGE));
+        }catch (Exception e) {
+            System.out.println("예외2");
+        }finally {
+            consumer.close();
+        }
+    }
+}
+
+/*      이전 kafka Topic 이름 넣는 코드.
+        String topic = "kafkaTest1";
+        consumer.subscribe(Arrays.asList(topic));*/
+
+/*          이전 ConsumerRecord 기록 가져오는 코드.
+            while (true) {
+            ConsumerRecords<String,String> records = consumer.poll(Duration.ofMillis(100));
+            for(ConsumerRecord<String,String> record:records) {
+                System.out.printf("Received notification: %s%n", record.value());
+            }
+        }
+*/

--- a/src/main/java/com/example/crawling/KafkaProducer.java
+++ b/src/main/java/com/example/crawling/KafkaProducer.java
@@ -1,0 +1,62 @@
+package com.example.crawling;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.util.StringUtils;
+
+import java.util.Properties;
+import java.util.Scanner;
+import java.util.concurrent.ExecutionException;
+
+public class KafkaProducer {
+    private static final String TOPIC_NAME = "kafkaTest1";
+    private static final String FIN_MESSAGE = "exit";
+
+
+    public static void main(String[] args) {
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", "localhost:9092"); // 카프카 서버의 위치를 지정.
+        properties.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer"); // 메시지의 키를 직렬화하는데 사용한 serializer(String -> byte)클래스 지정.
+        properties.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer"); // 메시지의 값을 직렬화하는데 사용한 serializer(String -> byte)클래스 지정.
+
+        Producer<String,String> producer = new org.apache.kafka.clients.producer.KafkaProducer<>(properties);
+
+
+        while (true) {
+            Scanner sc = new Scanner(System.in);
+            System.out.println("입력 >");
+            String message = sc.nextLine();
+
+            ProducerRecord<String,String> record = new ProducerRecord<>(TOPIC_NAME,message);
+            try {
+                producer.send(record,(metadata, exception) -> {
+                    if(exception !=null){
+                        System.out.println("예외");
+                    }
+                });
+            }catch (Exception e) {
+                System.out.println("예외1");
+            }finally {
+                producer.flush();
+            }
+
+            if(StringUtils.pathEquals(message,FIN_MESSAGE)) {
+                producer.close();
+                break;
+            }
+        }
+    }
+}
+
+
+/*      // 이전 코드
+        String topic = "kafkaTest1";
+        String key = "사용자1";
+        String value = "this is a push notification";
+
+        ProducerRecord<String, String> record = new ProducerRecord<>(topic,key,value);
+
+        producer.send(record);
+
+        producer.close();*/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 
+spring.kafka.bootstrap-servers=localhost:2100

--- a/src/test/java/com/example/crawling/KafkaProducerConsumerTest.java
+++ b/src/test/java/com/example/crawling/KafkaProducerConsumerTest.java
@@ -1,0 +1,58 @@
+package com.example.crawling;
+
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KafkaProducerConsumerTest {
+
+    private static final String TOPIC_NAME = "kafkaTest1";
+
+    @Test
+    public void testProducerAndConsumer() {
+
+        // producer 설정.
+        Properties producerProperties = new Properties();
+        producerProperties.put("bootstrap.servers", "localhost:9092");
+        producerProperties.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        producerProperties.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+        Producer<String, String> producer = new org.apache.kafka.clients.producer.KafkaProducer<>(producerProperties);
+
+        String key = "사용자1";
+        String value = "this is a push notification";
+        ProducerRecord<String, String> record = new ProducerRecord<>(TOPIC_NAME, key, value);
+
+        producer.send(record);
+        producer.close();
+
+        // consumer 설정.
+
+        Properties consumerProperties = new Properties();
+        consumerProperties.put("bootstrap.servers", "localhost:9092");
+        consumerProperties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        consumerProperties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        consumerProperties.put("group.id", "NotificationGroup");
+
+        Consumer<String, String> consumer = new org.apache.kafka.clients.consumer.KafkaConsumer<>(consumerProperties);
+
+        consumer.subscribe(Arrays.asList(TOPIC_NAME));
+
+        ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(10000));
+        for (ConsumerRecord<String, String> receivedRecord : records) {
+            assertEquals(key, receivedRecord.key());
+            assertEquals(value, receivedRecord.value());
+        }
+        consumer.close();
+    }
+}


### PR DESCRIPTION
MSA아케틱처, Apache Kafka

- apache kafka : 분산 스트리밍 플랫폼, 여러 서버에서 동시에 데이터를 처리 실시간 대량의 데이터를 처리할 수 있도록 설계.
- MSA : 애플리케이션을 독립적인 서비스로 나누는 아키텍처 스타일, 각 서비스는 독립적으로 배포, 확장 이를 통해 시스템의 유연성과 확장성 효율 증가. 

1. 분산 시스템 지원 : kafka는 클러스터를 이용해 분산 시스템을 지원함. 이러한 특성은 MSA와 잘 맞음. MSA는 여러개의 독립적인 병렬 서비스로 구성되는데, 서비스간의 통신과 데이터 교환을 효율적인 메시징 시스템(producer - broker - consumer, 대량의 실시간 데이터를 빠르게 처리 가능, 다수의 컨슈머에게 동시에 데이터 전달 가능.)으로 지원.
2. 실시간 데이터 처리 : kafka는 대량의 데이터를 빠르게 처리 가능. 이는 MSA 서비스간 지속적인 데이터 교환, 실시간 분석이 필요한 경우 효과적. 더 나아가 데이터 일관성 유지를 위한 kafka의 이벤트 소싱(상태변경을 이벤트로 기록, 이를 이용해 시스템의 상태를 재현), 로그 집계(대량의 로그 데이터를 처리해, 필요한 정보를 추출하고, 시스템의 상태를 파악) 을 통해 데이터 일관성 문제 해결. 
3. 고가용성, 내결함성 : kafka는 힌 노드가 실패해도 데이터 손실없이 서비스를 계속 제공 가능함. Fault-tolerant(고가용성) 이는 서비스 하나가 실패해도 시스템 전체에는 영향을 주지 않는 msa 구조에 적합함. 
4. 메시지 큐 기능 : 서비스간의 비동기 통신 방법을 가능케 함. 이를 통해, 서비스가 다른 서비스의 처리시간을 기다릴 필요 없이 자신의 작업을 계속 진행 가능.

# kafka

- 대용량, 대규모 데이터 처리를 위해 개발된 메시지 구독 시스템. 
- 생성자와 소비자 서로간의 의존성 존재하지 않음. 
  - 가운데 topic을 두고, 서로 topic에 관한 정보만 관여



특징 

- 클러스터(여러개의 서버를 그룹으로 묶어 한 단위로 운영) 
  - 한 서버에 문제가 생길시, 다른 서버가 그 역할을 대신 수행 가능. 
  - Falut-tolerant : 시스템의 일부에 문제가 생겨도, 전체 시스템이 계속 작동하는 능력 == 고가용성. 
- disk에 데이터 저장 
  - 데이터 유실 방지 : 메모리(전자적 접근: 메모리 쉘에 대한 정보가 전기 신호로 변환되어 처리)에 저장된 데이터는 전원이 꺼지거나 시스템에 문제시 손실될 위험이 존재.
  - Disk i/o : disk i/o는 상대적으로 느린 동작, 데이터를 무작위로 저장하는 것이 아닌 순차적 저장을 통해 효율성을 늘림. 
  - 대용량 데이터 처리 : 메모리에 비해 disk 용량은 훨씬 큼으로 대용량 데이터 처리, 저장하는 상황에 적합.
- 그렇다면 memory를 쓰는 이유? 
  - disk에 비해 접근 속도가 훨등히 빠르기 때문에 
    - 전자적 접근 : 메모리 쉘에 대한 정보가 전기 신호로 변환되어 처리.
  - disk(기계적 접근) 
    - 디스크 플래터의 원판이 회전하면서 올바른 위치로 이동.
      - 디스크의 회전속도 위치에 따라 속도가 상이함. 

기존 데이터 연결 방식 

- end to end 방식
  - 각 DB에서 원하는 시스템을 연결. 
- 데이터 종류 증가로 연동 복잡성 증가 -> 하드웨어,os 고려해 연결 발생 장애. 
- 기존 방식은 scale-out이 어려운 구조. 

Kafka 

- producer - topic(messaeg broker) - conusmer 
- Scale-out 용이(복제, 확장)
- Kafka broker
  - 실행된 kafka server을 의미함. 
  - 안정적인 서비스 제공을 위해 여러대의 서버를 클러스팅
  - zookeeper를 이용해 각 broker에게 데이터를 전달. 
- zookeeper 
  - 여러대의 서버(brokers)를 중재하고 연결하는 역할. 
  - 내부 broker의 메타 데이터(brokerId, controllerId등) 저장. 
- Kafka client 
  - kafka와 데이터를 주고받기 위한 JavaLibrary 
    - producer를 통해 메시지 생성 
      - Kafka 서버 주소, topic 명칭사용
    - consumer를 통해 메시지 사용
      - Kafka 서버 주소, topic 이름 
- kafka connect 
  - 데이터를 직접 import/export 
  - configuration으로 데이터 이동이 가능함. 
  - Restful API 통해서 지원, stream||batch 형태로 전송 가능. 
  - 가져오는 쪽 
    - kafka connect source
  - 보내는 쪽 
    - Kafka connect sink
  - Ex) 처리 예시 
    - MariaDB 데이터 변경시, kafka source connector를 통해 데이터 변경 감지, 이 내용을 topic에 담아 topic을 바라보고 있는 kafka sink connector에서 수신된 데이터를 담는 테이블에 데이터 입력 처리. 
    - ETL(extract transform load) 추출 변환 로드, 동일 기종, 다른 기종의 데이터로부터 데이터 추출해 다른 DB에 적재.
    - producer에서 데이터 전송 -> topic에서 데이터 수신 ,추가 -> kafka source connector를 통해 연결되어 mariaDB에 추가. 

구현 

알림 생성(특정 이벤트 발생시(좋아요,업데이트 등))에 반응하여 알림 메시지를 생성. 

이를 알림을 받아야하는 사용자의 정보와 함께 kafka의 프로듀서로 전송 

프로듀서는 알림 메시지를 kafka broker에게 전송. 

카프카 프로듀서는 이 메시지를 안전하게 저장하고, consumer에게 전달. 

consumer는 브로커로부터 알림 메시지를 받아서 처리. 


