### PR TITLE
kafkaTest2

### DIFF
--- a/src/main/java/com/example/crawling/kafkaTest1/KafkaConsumer.java
+++ b/src/main/java/com/example/crawling/kafkaTest1/KafkaConsumer.java
@@ -1,4 +1,4 @@
-package com.example.crawling;
+package com.example.crawling.kafkaTest1;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/src/main/java/com/example/crawling/kafkaTest1/KafkaProducer.java
+++ b/src/main/java/com/example/crawling/kafkaTest1/KafkaProducer.java
@@ -1,13 +1,11 @@
-package com.example.crawling;
+package com.example.crawling.kafkaTest1;
 
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.util.StringUtils;
 
 import java.util.Properties;
 import java.util.Scanner;
-import java.util.concurrent.ExecutionException;
 
 public class KafkaProducer {
     private static final String TOPIC_NAME = "kafkaTest1";
@@ -50,7 +48,7 @@ public class KafkaProducer {
 }
 
 
-/*      // 이전 코드
+/*      // 이전 코드 1
         String topic = "kafkaTest1";
         String key = "사용자1";
         String value = "this is a push notification";

--- a/src/main/java/com/example/crawling/kafkaTest2/consumer/NotificationConsumer.java
+++ b/src/main/java/com/example/crawling/kafkaTest2/consumer/NotificationConsumer.java
@@ -1,0 +1,45 @@
+package com.example.crawling.kafkaTest2.consumer;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+
+public class NotificationConsumer {
+    private static final String TOPIC_NAME = "kafkaTest2";
+    private static final String FIN_MESSAGE = "exit";
+
+    public static void main(String[] args) {
+        Properties properties = new Properties();
+
+        properties.put("bootstrap.servers", "localhost:9092");
+        properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        properties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        properties.put("group.id", "NotificationGroup");
+
+        Consumer<String,String> consumer = new KafkaConsumer<>(properties);
+        consumer.subscribe(Collections.singletonList(TOPIC_NAME)); // 왜 singletonlist로 갖고 오지?
+
+        String message = null;
+
+        try {
+            do{
+                ConsumerRecords<String,String> records = consumer.poll(Duration.ofMillis(100000));
+                for(ConsumerRecord<String,String> record:records) {
+                    message = record.value();
+                    System.out.println("알림 : " + message);
+                }
+            }while (message!=null && !FIN_MESSAGE.equals(message));
+        }catch (Exception e) {
+            e.printStackTrace();
+            System.out.println("알림 처리간 에러 발생");
+        }finally {
+            consumer.close();
+        }
+    }
+}

--- a/src/main/java/com/example/crawling/kafkaTest2/dto/Notification.java
+++ b/src/main/java/com/example/crawling/kafkaTest2/dto/Notification.java
@@ -1,0 +1,28 @@
+package com.example.crawling.kafkaTest2.dto;
+
+
+public class Notification {
+    private String email;
+    private String message;
+
+    public Notification(String email, String message) {
+        this.email = email;
+        this.message = message;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/crawling/kafkaTest2/producer/NotificationProducer.java
+++ b/src/main/java/com/example/crawling/kafkaTest2/producer/NotificationProducer.java
@@ -1,0 +1,38 @@
+package com.example.crawling.kafkaTest2.producer;
+import com.example.crawling.kafkaTest2.dto.Notification;
+import com.example.crawling.kafkaTest2.service.NotificationService;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.util.Properties;
+public class NotificationProducer {
+
+    private static final String TOPIC_NAME = "kafkaTest2";
+
+    public static void main(String[] args) {
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", "localhost:9092");
+        properties.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        properties.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+
+        Producer<String,String> producer = new KafkaProducer<>(properties);
+
+        NotificationService notificationService = new NotificationService();
+        Notification notification = notificationService.createNotification("zkdl6565@naver.com","zkdl6565@naver.com send you a message");
+
+        String message = String.format("TO: %s, Message : %s", notification.getEmail(), notification.getMessage());
+
+        producer.send(new ProducerRecord<>(TOPIC_NAME, message), (metadata, exception) -> {
+            if (exception != null) {
+                exception.printStackTrace();
+            } else {
+                System.out.println("Sent message: (" + metadata.topic() + ", " + metadata.partition() + ", " + metadata.offset() + ")");
+            }
+        });
+        producer.close();
+
+
+    }
+}

--- a/src/main/java/com/example/crawling/kafkaTest2/service/NotificationService.java
+++ b/src/main/java/com/example/crawling/kafkaTest2/service/NotificationService.java
@@ -1,0 +1,10 @@
+package com.example.crawling.kafkaTest2.service;
+
+import com.example.crawling.kafkaTest2.dto.Notification;
+
+public class NotificationService {
+
+    public Notification createNotification(String email, String message) {
+        return new Notification(email,message);
+    }
+}


### PR DESCRIPTION
# MOM(message oriented Middleware) 

---

- kafka : 대용량의 실시간 로그, 스크림 데이터 처리에 특화, 데이터를 토픽으로 분류하고, 이 토픽을 여러 파티션으로 나누어 분산 시스템에서 확장성을 달성함. 
- rabbitMq : AMQP(advanced message queuing protocol)를 기반으로 하는 오픈 소스 메시지 브로커로, 비동기 메시징을 지원함. 다양한 메시지 라우팅 모델을 지원하며, 특히 불확실한 네트워크(rabbitMq의 특징 : publisher, consumer 사이에서 메시지 전달의 안전성을 보장하기 위해 메시지 확인 메커니즘을 제공함. 이는 메시지가 전달되지 않을 경우에도 재전송을 요청할 수 있음. 더 나아가 메시지의 지속성을 설정해, 서버가 다운되더라도 메시지가 유실되지 않도록 함.)
- Google pub/sub : 이는 google cloud에서 제공하는 완전 관리형 서비스. 대규모의 데이터를 신속하게 분석하고 처리할 수 있으며, goole cloud의 다른 서비스와의 호환성(이 이유는 google cloud platform(gcp)의 일부이기 때문, 그로 인해 gcp의 다른 서비스들과 자연스럽게 연동이 가능하기 때문에 효율적인 시스템을 구축 가능함)이 탁월

구현 

- 알림 정의 : 알림에 들어갈 정보
- 알림 생성 : 알림이 필요한 시점에 알림 생성 로직 작성 ->  메시지를 받았을 때 알림 생성
- producer : 알림 생성 로직에서 Kafka 알림을 전송하는 코드 추가
- consumer : 알림을 받고 처리하는 로직을 추가. 
- 알림 처리 : consumer가 알림을 받으면, 이를 처리하는 작업(알림을 사용자에게 표시) 
- 테스트 : kafka 서버 실행 -> producer 클래스실행 -> consumer 클래스 실행(producer에서 보낸 메시지 넘어왔는지 확인)

/usr/local/bin/kafka-topics --list --bootstrap-server localhost:9092 // 9092서버의 토픽 리스트 찾기. 

Brew services start zookeeper // 주키퍼 시작.(토픽, 브로커 등의 메타 데이터,상태 관리,  Kafka 클러스터내에서 리더 선출, 장애 복구 등의 작업을 코디네이션 하는데 사용. 위의 내용과 관련해서 kafka가 zookeeper에 의존하여 클러스터의 상태와 메타 데이터를 관리하기 때문에)

brew Services start Kafka // 카프카 시작. 

