### PR TITLE
Kafka&&FCM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.jsoup:jsoup:1.14.3' // 크롤링
     implementation 'org.springframework.kafka:spring-kafka' // 카프카
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3' // jackson 라이브러리
+    implementation 'com.google.firebase:firebase-admin:7.2.0' // firebase
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// 재정의 api가 java에서 권장하지 않는 deprecated API를 사용하고 있다는것을 알려줌.
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:deprecation"
 }

--- a/src/main/java/com/example/crawling/kafkaTest3/consumer/NotificationConsumer.java
+++ b/src/main/java/com/example/crawling/kafkaTest3/consumer/NotificationConsumer.java
@@ -1,0 +1,47 @@
+package com.example.crawling.kafkaTest3.consumer;
+
+import com.example.crawling.kafkaTest3.dto.Payload;
+import com.example.crawling.kafkaTest3.service.NotificationService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+
+public class NotificationConsumer {
+    private static final String TOPIC_NAME = "kafkaTest3";
+
+    public static void main(String[] args) {
+        Properties properties = new Properties();
+
+        properties.put("bootstrap.servers", "localhost:9092");
+        properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        properties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        properties.put("group.id", "NotificationGroup");
+
+
+        Consumer<String, String>  consumer = new KafkaConsumer<>(properties);
+        consumer.subscribe(Collections.singletonList(TOPIC_NAME));
+
+
+        while (true) {
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(10000));
+
+            for (ConsumerRecord<String, String> record : records) {
+                String json = record.value();
+                try {
+                    Payload payload = Payload.fromJson(json);
+                    NotificationService notificationService = new NotificationService();
+                    notificationService.sendPushNotification(payload.getUserEmail(), payload.getMessage());
+                    // System.out.println("새 알림 :" + payload.getMessage()); 콘솔 응답 처리
+                } catch (JsonProcessingException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/crawling/kafkaTest3/consumer/NotificationConsumer.java
+++ b/src/main/java/com/example/crawling/kafkaTest3/consumer/NotificationConsumer.java
@@ -22,6 +22,7 @@ public class NotificationConsumer {
         properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
         properties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
         properties.put("group.id", "NotificationGroup");
+        properties.put("max.poll.records","1"); // 한번에 하나의 메시지만 가져오도록 설정 추가. -> 메시지 순차 처리, 순서 보장.
 
 
         Consumer<String, String>  consumer = new KafkaConsumer<>(properties);

--- a/src/main/java/com/example/crawling/kafkaTest3/dto/Payload.java
+++ b/src/main/java/com/example/crawling/kafkaTest3/dto/Payload.java
@@ -1,27 +1,28 @@
 package com.example.crawling.kafkaTest3.dto;
 
-import org.springframework.boot.json.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class Payload {
 
+public class Payload {
     private String userEmail;
     private String message;
 
-    public Payload(String userEmail, String message) {
-        this.userEmail = userEmail;
-        this.message = message;
-    }
+    // 생성자, getter, setter 생략...
 
     public static Payload fromJson(String json) throws JsonProcessingException {
-            ObjectMapper mapper = new ObjectMapper();
-            return mapper.readValue(json, Payload.class);
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, Payload.class);
     }
 
     public String toJson() throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.writeValueAsString(this);
+    }
+
+    public Payload(String userEmail, String message) {
+        this.userEmail = userEmail;
+        this.message = message;
     }
 
     public String getUserEmail() {

--- a/src/main/java/com/example/crawling/kafkaTest3/dto/Payload.java
+++ b/src/main/java/com/example/crawling/kafkaTest3/dto/Payload.java
@@ -1,0 +1,42 @@
+package com.example.crawling.kafkaTest3.dto;
+
+import org.springframework.boot.json.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class Payload {
+
+    private String userEmail;
+    private String message;
+
+    public Payload(String userEmail, String message) {
+        this.userEmail = userEmail;
+        this.message = message;
+    }
+
+    public static Payload fromJson(String json) throws JsonProcessingException {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(json, Payload.class);
+    }
+
+    public String toJson() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public void setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/crawling/kafkaTest3/producer/NotificationProducer.java
+++ b/src/main/java/com/example/crawling/kafkaTest3/producer/NotificationProducer.java
@@ -23,7 +23,9 @@ public class NotificationProducer {
 
         Payload payload = new Payload("zkdl6565@naver.com","새로운 메시지 발송");
 
-        producer.send(new ProducerRecord<>(TOPIC_NAME, payload.toJson()));
+        String chatRoomId = "chatroom1"; // 채팅방 id를 키로 사용하여 메시지 생성.
+
+        producer.send(new ProducerRecord<>(TOPIC_NAME, chatRoomId,payload.toJson())); // chatroomId를 통해 동일 파티션 할당 -> 메시지 순서 보장.
 
         producer.close();
     }

--- a/src/main/java/com/example/crawling/kafkaTest3/producer/NotificationProducer.java
+++ b/src/main/java/com/example/crawling/kafkaTest3/producer/NotificationProducer.java
@@ -1,0 +1,30 @@
+package com.example.crawling.kafkaTest3.producer;
+
+import com.example.crawling.kafkaTest3.dto.Payload;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.util.Properties;
+
+
+public class NotificationProducer {
+
+    private static final String TOPIC_NAME = "kafkaTest3";
+
+    public static void main(String[] args) throws JsonProcessingException {
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", "localhost:9092");
+        properties.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        properties.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+        Producer<String,String> producer = new KafkaProducer<>(properties);
+
+        Payload payload = new Payload("zkdl6565@naver.com","새로운 메시지 발송");
+
+        producer.send(new ProducerRecord<>(TOPIC_NAME, payload.toJson()));
+
+        producer.close();
+    }
+}

--- a/src/main/java/com/example/crawling/kafkaTest3/service/NotificationService.java
+++ b/src/main/java/com/example/crawling/kafkaTest3/service/NotificationService.java
@@ -1,0 +1,20 @@
+package com.example.crawling.kafkaTest3.service;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+public class NotificationService {
+    public void sendPushNotification(String deviceToken, String message) {
+        Message message1 = Message.builder()
+                .putData("message", message)
+                .setToken(deviceToken)
+                .build();
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message1);
+            System.out.println("메시지 전송 성공 : " + response);
+        } catch (FirebaseMessagingException e) {
+            System.out.println("메시지 전송 실패 : " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
# Kafka,Fcm을 이용한 푸쉬알람 시스템 구현

---

푸쉬 알람 구현시 고려해야 할 점. 

- 스케일링 : 푸쉬 알람의 수신자가 수천명, 수만명 혹은 그 이상으로 많아질 경우, kafka의 파티션 설정, conusmer의 병렬처리 등에 대한 고려가 필요. 또한 fcm의 경우엔 한번에 보낼수 있는 메시지 수가 제한되 있기 때문에 이를 고려한 구현이 필요함. 
- 메시지 순서 보장 : kafka는 토픽의 파티션 단위로 메시지의 순서를 보장. 만약 메시지의 순서가 중요한 시스템일 경우, 파티션 설정과 consumer의 처리 로직에 신경을 써야 함.
- 에러 핸들링 : 네트워크 이슈, fcm 서버의 문제, 잘못된 토큰 등 다양한 이유로 메시지 전송이 실패할 수 있음. 이 경우를 대비한 에러 핸들링 처리가 필요하며, 재시도 메커니즘  구현도 고려해야 합니다. 
- 보안 : fcm 토큰은 사용자를 식별하는 중요한 정보임으로, 이를 안전하게 저장하고 전송하는 것이 중요. 또한 메시지 내용 역시 중요한 정보를 담고 있음으로 암호화등의 보안 처리가 필요함. 
- 모니터링 : 시스템의 정상 작동을 위해서는 kafka의 상태, fcm의 전송 성공률 등을 모니터링 하고 이상 징후를 빠르게 파악할 수 있는 시스템이 필요함. 



구현 

- Kafka 서버 실행(zookeeper 구동)
- firebase프로젝트 생성 및 설정
  - 새 프로젝트 생성, firebase admin sdk를 실행 프로젝트에 추가
- kafkaProducer 
  - producer 코드 실행, kafka에 채팅방 별로 메시지 발행, 이때 메시지는 fcm 토픽, 값은 전송할 메시지로 설정.  
- kafkaConsumer 
  - consumer 코드 실행해, kafka에서 메시지를 소비하고, 이를 fcm에 전송. 
- android studio를 통해, 해당 fcm을 구독하고 있는 기기에 푸시 알람이 정상적으로 수신되는지 확인



현재 프로젝트에선, 이전 이벤트와 후속 이벤트와의 연관 관계가 필요하지 않음. -> 그래서 메시지의 순서는 중요하지 않음 

다만 연관 이벤트에 대한 추가 기능 추가를 고려해, 설정을 공부해둘 필요가 있다 생각함. 

- max.poll.records 설정을 통해 하나의 메시지를 처리
- 채팅방마다 하나의 컨슈머를 할당해 순서를 보장
  - 이 경우엔 순서가 보장되지만, 리소스 사용증가라는 단점이 존재함.

- kafkaProducer -> kafka의 파티션 설정

  - producer가 메시지를 보낼때, 특정 키를 지정하여 동일한 파티션에 라우팅되도록 할 수 있음. 

  - => 이를 통해 파티션 단위로 메시지의 순서 보장 -> key를 통해 동일한 파티션에 라우팅.

  - ex) 

    - ```java
       // 채팅방 ID를 키로 사용하여 메시지를 생성합니다.
              String chatroomId = "chatroom1";
      
              producer.send(new ProducerRecord<>(TOPIC_NAME, chatroomId, payload.toJson()));
      ```

- kafkaConsumer -> 처리 로직

  - kafka에서 메시지를 가져오는 방식을 제어, kafka의 'max.poll.records' 설정을 통해 가져올 메시지의 갯수를 제한함. 

  - ex)

    - ```java
          public static void main(String[] args) {
              Properties properties = new Properties();
      
              properties.put("bootstrap.servers", "localhost:9092");
              properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
              properties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
              properties.put("group.id", "NotificationGroup");
              // 최대 한 번에 가져올 레코드 수를 1로 설정
              properties.put("max.poll.records", "1");
      ```

